### PR TITLE
[feat] #3 user API 구현

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,5 +1,82 @@
 const userModel = require("../models/authModel");
 
+// 회원가입
+async function createUser(req, res) {
+    var post = req.body;
+    var userInfo = [post.userSignId, post.userNickname, post.userPassword];
+    var result = await userModel.insertUser(userInfo);
+    if (!result)
+        res.json({ "result": "FAIL" });
+    else
+        res.json({ "result": "SUCCESS" });
+}
+
+// 로그인
+async function checkUserById(req, res) {
+    var post = req.body;
+    var result = await userModel.getUserById(post.userSignId);
+    if (!result.length) // 아이디 여부 확인
+        res.json({ "result": "FAIL" });
+    else {
+        if (result[0].user_password == post.password) // 비밀번호 확인
+            res.json({ "result": "SUCCESS", "userId": result[0].signId, "userNickname": result[0].nickname });
+        else
+            res.json({ "result": "FAIL" });
+    }
+
+}
+
+// 회원 정보 조회
+async function getUserInfoById(req, res) {
+    var post = req.body;
+    var result = await userModel.getUserById(post.userSignId);
+    if (!result.length) // 아이디 여부 확인
+        res.json({ "result": "FAIL" });
+    else
+        res.json({ "result": "SUCCESS", "userId": result[0].signId, "userNickname": result[0].nickname, "userStatusMsg": result[0].statusMsg });
+}
+
+// 회원 정보 수정
+async function updateUserInfo(req, res) {
+    var post = req.body;
+    var newUserInfo = [post.userNickname, post.userPassword, userStatusMsg, post.userSignId];
+    var result = await userModel.updateUserInfoById(newUserInfo);
+    if (!result)
+        res.json({ "result": "FAIL" });
+    else
+        res.json({ "result": "SUCCESS" });
+}
+
+// 회원 탈퇴 시, 비밀번호 확인
+async function getUserPasswordCorrect(req) {
+    var post = req.body;
+    var result = await userModel.getUserById(post.userSignId);
+    if (result[0].password == post.userPassword)
+        return true;
+    else
+        return false;
+}
+
+// 회원 탈퇴
+async function deleteUser(req, res) {
+    var post = req.body;
+    var correctResult = await getUserPasswordCorrect(req);
+    if (!correctResult) {
+        res.json({ "result": "FAIL" });
+    } else {
+        var result = await userModel.deleteUserById(correctResult);
+        if (!result)
+            res.json({ "result": "FAIL" });
+        else
+            res.json({ "result": "SUCCESS" });
+    }
+}
+
 module.exports = {
-    
+    createUser,
+    checkUserById,
+    getUserInfoById,
+    updateUserInfo,
+    getUserPasswordCorrect,
+    deleteUser
 }

--- a/models/authModel.js
+++ b/models/authModel.js
@@ -1,5 +1,61 @@
 const pool = require('../modules/pool');
 
+// 회원가입
+async function insertUser(user) {
+    const query = `INSERT INTO user (signId, nickname, password) VALUES (?, ?, ?)`;
+    try {
+        const result = await pool.queryParam(query, user);
+        return result;
+    } catch (error) {
+        return null;
+    }
+}
+
+// 아이디 여부 검사
+async function getUserById(userId) {
+    const query = `SELECT * FROM user WHERE signId=?`;
+    try {
+        const result = await pool.queryParam(query, userId).catch(
+            function(error) {
+                return null;
+            });
+        return result;
+    } catch (error) {
+        return null;
+    }
+}
+
+// 회원 정보 수정
+async function updateUserInfoById(newUserInfo) {
+    const query = `UPDATE user SET nickname=?, password=?, statusMsg=? WHERE signId=?`;
+    try {
+        const result = await pool.queryParam(query, newUserInfo).catch(
+            function(error) {
+                return null;
+            });
+        return result;
+    } catch (error) {
+        return null;
+    }
+}
+
+// 회원 탈퇴
+async function deleteUserById(userId) {
+    const query = `DELETE FROM user WHERE signId=?`;
+    try {
+        const result = await pool.queryParam(query, userId).catch(
+            function(error) {
+                return null;
+            });
+        return result;
+    } catch (error) {
+        return null;
+    }
+}
+
 module.exports = {
-    
+    insertUser,
+    getUserById,
+    updateUserInfoById,
+    deleteUserById
 }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -2,4 +2,19 @@ var express = require('express');
 var router = express.Router();
 var authController = require('../controllers/authController');
 
+// 회원가입
+router.post('/auth/signup',authController.createUser);
+
+// 로그인
+router.post('/auth/signin', authController.checkUserById);
+
+// 회원 정보 조회
+router.post('/auth/user', authController.getUserInfoById);
+
+// 회원 정보 수정
+router.post('/auth/user/update', authController.updateUserInfo);
+
+// 회원 탈퇴
+router.post('/auth/user/delete', authController.deleteUser);
+
 module.exports = router;


### PR DESCRIPTION
## 관련 이슈
- #3 

## 작업 내용
- `feat` [auth route, model, controller 구현](https://github.com/QmA-project/QmA-server/commit/2eb480a3f24a976a3e2610ef431a0a773daf9230)

## 고민
![image](https://user-images.githubusercontent.com/48620082/206354367-e147633e-9e09-43bf-a45a-69a7964829f3.png)
- 회원 정보 조회
  - /auth/user GET으로 회원 정보 조회 맞을까요?
  - body 부분 userId -> userSignId 으로 변경해서 구현해두었는데 괜찮은지 확인 부탁드립니다
  - response 부분 첨부한 이미지대로 userId, userNickname, userStatusMsg로 바꾸면 좋을 것 같습니다
- 회원 정보 수정
  - body 부분 userSignId를 맨 마지막 순서로 받아야만 할 것 같은데 안그래도 되는지 궁금합니다
- 컨벤션
  - body 받을 때 유저 아이디를 userSignId로 할건지, userId로 할건지 정해야할 것 같습니다! user DB 조회 시에만 userSignId이고 나머진 userId인지 기준이 궁금합니다!