### PR TITLE
[feat] #5 question API 구현

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -2,11 +2,11 @@ require('dotenv').config();
 var mysql = require('mysql');
 
 const pool = {
-    host     : process.env.DATABASE_HOST,
-    user     : process.env.DATABASE_USERNAME,
-    password : process.env.DATABASE_PASSWORD,
-    database : process.env.DATABASE_NAME,
-    connectionLimit : 0
+    host: process.env.DATABASE_HOST,
+    user: process.env.DATABASE_USERNAME,
+    password: process.env.DATABASE_PASSWORD,
+    database: process.env.DATABASE_NAME,
+    connectionLimit: 0
 };
 
 

--- a/controllers/questionController.js
+++ b/controllers/questionController.js
@@ -1,8 +1,9 @@
-const userModel = require("../models/questionModel");
+const questionModel = require("../models/questionModel");
 
 // 공개 질문 목록 조회
 async function getPublicQuestionListByGroupId(req, res) {
-    var result = await questionModel.getQuestionListDataByGroupId(0);
+    const PUBLIC_GROUP_ID = 1;
+    var result = await questionModel.getQuestionListDataByGroupId(PUBLIC_GROUP_ID);
     if (!result)
         res.json({ "result": "FAIL" });
     else {

--- a/controllers/questionController.js
+++ b/controllers/questionController.js
@@ -67,11 +67,11 @@ async function getDailyQuestion(req, res) {
 // HOT 질문 조회
 async function getDailyHotQuestion(req, res) {
     var post = req.body;
-    var result = await questionModel.getDailyQuestionData(post.todayDate);
+    var result = await questionModel.getDailyHotQuestionData(post.todayDate);
     if (!result)
         res.json({ "result": "FAIL" });
     else {
-        res.json({ "result": "SUCCESS", 'questionId': result[0].questionId, "content": result[0].content });
+        res.json({ "result": "SUCCESS", 'questionId': result[0].questionId, "content": result[0].content, "createdAt": result[0].createdAt, "numOfAnswers": result[0].numOfAnswers });
     }
 }
 

--- a/controllers/questionController.js
+++ b/controllers/questionController.js
@@ -1,5 +1,84 @@
 const userModel = require("../models/questionModel");
 
+// 공개 질문 목록 조회
+async function getPublicQuestionListByGroupId(req, res) {
+    var result = await questionModel.getQuestionListDataByGroupId(0);
+    if (!result)
+        res.json({ "result": "FAIL" });
+    else {
+        var questions = JSON.parse(result);
+        res.json({ "result": "SUCCESS", "questions": questions });
+    }
+}
+
+// 질문 조회
+async function getQuestionByQuestionId(req, res) {
+    var questionId = req.params.questionId;
+    var result = await questionModel.getQuestionDataByQuestionId(questionId);
+    if (!result)
+        res.json({ "result": "FAIL" });
+    else {
+        var questions = JSON.parse(result);
+        res.json({ "result": "SUCCESS", "questions": questions });
+    }
+}
+
+// 전체 그룹 질문 조회
+async function getAllGroupQuestionListByUserId(req, res) {
+    var post = req.body;
+    var questionResult = await questionModel.getGroupQuestionListDataByUserId(post.userId);
+    // TODO: groupId 따로 구해서 가져와야함...
+    var groupResult = await questionModel.getGroupDataByGroupId(groupId);
+    if (!questionsResult || !groupResult)
+        res.json({ "result": "FAIL" });
+    else {
+        var group = JSON.parse(groupResult);
+        var questions = JSON.parse(questionResult);
+        res.json({ "result": "SUCCESS", group, "questions": questions });
+    }
+}
+
+// 하나의 그룹에서 질문 목록 조회
+async function getGroupQuestionListByGroupId(req, res) {
+    var groupId = req.params.groupId;
+    var groupResult = await questionModel.getQuestionListDataByGroupId(groupId);
+    var questionResult = await questionModel.getGroupDataByGroupId(groupId);
+    if (!questionsResult || !groupResult)
+        res.json({ "result": "FAIL" });
+    else {
+        var group = JSON.parse(groupResult);
+        var questions = JSON.parse(questionResult);
+        res.json({ "result": "SUCCESS", group, "questions": questions });
+    }
+}
+
+// 오늘의 질문 조회
+async function getDailyQuestion(req, res) {
+    var post = req.body;
+    var result = await questionModel.getDailyQuestionData(post.todayDate);
+    if (!result)
+        res.json({ "result": "FAIL" });
+    else {
+        res.json({ "result": "SUCCESS", 'questionId': result[0].questionId, "content": result[0].content });
+    }
+}
+
+// HOT 질문 조회
+async function getDailyHotQuestion(req, res) {
+    var post = req.body;
+    var result = await questionModel.getDailyQuestionData(post.todayDate);
+    if (!result)
+        res.json({ "result": "FAIL" });
+    else {
+        res.json({ "result": "SUCCESS", 'questionId': result[0].questionId, "content": result[0].content });
+    }
+}
+
 module.exports = {
-    
+    getPublicQuestionListByGroupId,
+    getQuestionByQuestionId,
+    getAllGroupQuestionListByUserId,
+    getGroupQuestionListByGroupId,
+    getDailyQuestion,
+    getDailyHotQuestion
 }

--- a/models/questionModel.js
+++ b/models/questionModel.js
@@ -122,9 +122,10 @@ async function getGroupDataByGroupId(groupId) {
 
 // 오늘의 질문 조회
 async function getDailyQuestionData(todayDate) {
-    const query = `SELECT * FROM question WHERE createdAt.date=? AND isDaily=true`;
+    const todayDateWildStr = todayDate + '%';
+    const query = `SELECT * FROM question WHERE createdAt LIKE ? AND isDaily=true;`;
     try {
-        const result = await pool.queryParam(query, todayDate).catch(
+        const result = await pool.queryParam(query, todayDateWildStr).catch(
             function(error) {
                 console.log(error);
                 return null;

--- a/models/questionModel.js
+++ b/models/questionModel.js
@@ -138,11 +138,10 @@ async function getDailyQuestionData(todayDate) {
 
 // HOT 질문 조회
 async function getDailyHotQuestionData(todayDate) {
-    // TODO: 쿼리 짜리
-    // 오늘 작성된 질문 중 댓글 가장 많은 질문
-    const query = `SELECT * FROM question WHERE createdAt.date=?`;
+    const todayDateWildStr = todayDate + '%';
+    const query = `SELECT question.questionId, question.content, question.createdAt, COUNT(question.questionId) AS numOfAnswers FROM question LEFT OUTER JOIN answer ON question.questionId=answer.questionId WHERE question.createdAt LIKE ? GROUP BY question.questionId ORDER BY numOfAnswers desc limit 1`;
     try {
-        const result = await pool.queryParam(query, todayDate).catch(
+        const result = await pool.queryParam(query, todayDateWildStr).catch(
             function(error) {
                 console.log(error);
                 return null;

--- a/models/questionModel.js
+++ b/models/questionModel.js
@@ -2,7 +2,7 @@ const pool = require('../modules/pool');
 
 // 질문 목록 조회
 async function getQuestionListDataByGroupId(groupId) {
-    const query = `SELECT * FROM question WHERE question.groupId=?;`;
+    const query = 'SELECT * FROM question WHERE question.groupId=?;';
     try {
         const result = await pool.queryParam(query, groupId).catch(
             function(error) {

--- a/models/questionModel.js
+++ b/models/questionModel.js
@@ -2,7 +2,7 @@ const pool = require('../modules/pool');
 
 // 질문 목록 조회
 async function getQuestionListDataByGroupId(groupId) {
-    const query = 'SELECT * FROM question WHERE question.groupId=?;';
+    const query = `SELECT question.questionId, question.content, question.createdAt, COUNT(question.questionId) AS numOfAnswers FROM question LEFT OUTER JOIN answer ON question.questionId=answer.questionId WHERE question.groupId=? GROUP BY question.questionId;`
     try {
         const result = await pool.queryParam(query, groupId).catch(
             function(error) {
@@ -15,9 +15,9 @@ async function getQuestionListDataByGroupId(groupId) {
             question.questionId = questionData.questionId;
             question.content = questionData.content;
             question.createdAt = questionData.createdAt;
+            question.numOfAnswers = questionData.numOfAnswers;
             questionInfo.push(question);
         }
-        // TODO: numOfAnswers 추가해야함
         questionInfo = JSON.stringify(questionInfo);
         return questionInfo;
     } catch (error) {

--- a/models/questionModel.js
+++ b/models/questionModel.js
@@ -1,5 +1,162 @@
 const pool = require('../modules/pool');
 
+// 질문 목록 조회
+async function getQuestionListDataByGroupId(groupId) {
+    const query = `SELECT * FROM question WHERE question.groupId=?;`;
+    try {
+        const result = await pool.queryParam(query, groupId).catch(
+            function(error) {
+                console.log(error);
+                return null;
+            });
+        var questionInfo = [];
+        for (questionData of result) {
+            var question = {};
+            question.questionId = questionData.questionId;
+            question.content = questionData.content;
+            question.createdAt = questionData.createdAt;
+            questionInfo.push(question);
+        }
+        // TODO: numOfAnswers 추가해야함
+        questionInfo = JSON.stringify(questionInfo);
+        return questionInfo;
+    } catch (error) {
+        return false;
+    }
+}
+
+// 질문 조회
+async function getQuestionDataByQuestionId(questionId) {
+    const query = `SELECT * FROM question WHERE question.questionId=?;`;
+    try {
+        const result = await pool.queryParam(query, questionId).catch(
+            function(error) {
+                console.log(error);
+                return null;
+            });
+        var questionInfo = [];
+        for (questionData of result) {
+            var question = {};
+            question.questionId = questionData.questionId;
+            question.content = questionData.content;
+            question.createdAt = questionData.createdAt;
+            question.userId = questionData.userId;
+            question.userNickname = questionData.userNickname;
+            question.isAnswerPrivate = questionData.isAnswerPrivate;
+            questionInfo.push(question);
+        }
+        questionInfo = JSON.stringify(questionInfo);
+        return questionInfo;
+    } catch (error) {
+        return false;
+    }
+}
+
+// 전체 그룹 질문 조회
+async function getGroupQuestionListDataByUserId(userId) {
+    // TODO: 쿼리 짜기
+    // userId를 통해 groupId의 목록들을 가져오고...groupId로 group table에서 각각 해당 groupId의 정보들을 가져오기 + question table에서 question 정보가져오기
+    // userId로 groupId를 조회하는 함수를 따로 만드는 게 더 나은가?
+    const query = `SELECT * FROM question WHERE question.groupId=groupId;`;
+    try {
+        const result = await pool.queryParam(query, userId).catch(
+            function(error) {
+                console.log(error);
+                return null;
+            });
+        var questionInfo = [];
+        for (questionData of result) {
+            var question = {};
+            question.questionId = questionData.questionId;
+            question.content = questionData.content;
+            question.createdAt = questionData.createdAt;
+            question.push(question);
+        }
+        // TODO: numOfMembers, numOfAnswers 추가해야함
+        questionInfo = JSON.stringify(questionInfo);
+        return questionInfo;
+    } catch (error) {
+        return false;
+    }
+}
+
+// userId로 groupId 목록 조회
+async function getGroupIdDataByUserId(userId) {
+    const query = `SELECT groupId FROM user_group WHERE userId=?`;
+    try {
+        const result = await pool.queryParam(query, todayDate).catch(
+            function(error) {
+                console.log(error);
+                return null;
+            });
+        return result;
+    } catch (error) {
+        return false;
+    }
+}
+
+// 그룹 정보 조회
+async function getGroupDataByGroupId(groupId) {
+    const query = `SELECT * FROM group WHERE group.groupId=?;`;
+    try {
+        const result = await pool.queryParam(query, groupId).catch(
+            function(error) {
+                console.log(error);
+                return null;
+            });
+        var groupInfo = [];
+        for (groupData of result) {
+            var group = {};
+            group.groupId = groupData.groupId;
+            group.groupName = groupData.name;
+            group.colorCode = groupData.colorCode;
+            groupInfo.push(group);
+        }
+        // TODO: numOfMembers 추가해야함
+        groupInfo = JSON.stringify(groupInfo);
+        return groupInfo;
+    } catch (error) {
+        return false;
+    }
+}
+
+// 오늘의 질문 조회
+async function getDailyQuestionData(todayDate) {
+    const query = `SELECT * FROM question WHERE createdAt.date=? AND isDaily=true`;
+    try {
+        const result = await pool.queryParam(query, todayDate).catch(
+            function(error) {
+                console.log(error);
+                return null;
+            });
+        return result;
+    } catch (error) {
+        return false;
+    }
+}
+
+// HOT 질문 조회
+async function getDailyHotQuestionData(todayDate) {
+    // TODO: 쿼리 짜리
+    // 오늘 작성된 질문 중 댓글 가장 많은 질문
+    const query = `SELECT * FROM question WHERE createdAt.date=?`;
+    try {
+        const result = await pool.queryParam(query, todayDate).catch(
+            function(error) {
+                console.log(error);
+                return null;
+            });
+        return result;
+    } catch (error) {
+        return false;
+    }
+}
+
 module.exports = {
-    
+    getQuestionListDataByGroupId,
+    getQuestionDataByQuestionId,
+    getGroupQuestionListDataByUserId,
+    getGroupDataByGroupId,
+    getDailyQuestionData,
+    getDailyHotQuestionData
 }

--- a/routes/question.js
+++ b/routes/question.js
@@ -2,4 +2,22 @@ var express = require('express');
 var router = express.Router();
 var questionController = require('../controllers/questionController');
 
+// 공개 질문 목록 조회
+router.get('/questions', questionController.getPublicQuestionListByGroupId);
+
+// 질문 조회
+router.get('/questions/:questionId', questionController.getQuestionByQuestionId);
+
+// 전체 그룹 질문 조회
+router.post('/questions/group', questionController.getAllGroupQuestionListByUserId);
+
+// 하나의 그룹에서 질문 목록 조회
+router.get('/questions/group/:groupId', questionController.getGroupQuestionListByGroupId);
+
+// 오늘의 질문 조회
+router.post('/questions/today', questionController.getDailyQuestion);
+
+// HOT 질문 조회
+router.post('/questions/hot', questionController.getDailyHotQuestion);
+
 module.exports = router;

--- a/routes/question.js
+++ b/routes/question.js
@@ -3,21 +3,21 @@ var router = express.Router();
 var questionController = require('../controllers/questionController');
 
 // 공개 질문 목록 조회
-router.get('/questions', questionController.getPublicQuestionListByGroupId);
+router.get('/', questionController.getPublicQuestionListByGroupId);
 
 // 질문 조회
-router.get('/questions/:questionId', questionController.getQuestionByQuestionId);
+router.get('/:questionId', questionController.getQuestionByQuestionId);
 
 // 전체 그룹 질문 조회
-router.post('/questions/group', questionController.getAllGroupQuestionListByUserId);
+router.post('/group', questionController.getAllGroupQuestionListByUserId);
 
 // 하나의 그룹에서 질문 목록 조회
-router.get('/questions/group/:groupId', questionController.getGroupQuestionListByGroupId);
+router.get('/group/:groupId', questionController.getGroupQuestionListByGroupId);
 
 // 오늘의 질문 조회
-router.post('/questions/today', questionController.getDailyQuestion);
+router.post('/today', questionController.getDailyQuestion);
 
 // HOT 질문 조회
-router.post('/questions/hot', questionController.getDailyHotQuestion);
+router.post('/hot', questionController.getDailyHotQuestion);
 
 module.exports = router;


### PR DESCRIPTION
## 관련 이슈
- #5 

## 작업 내용
- 공개 질문 목록 조회: `getPublicQuestionListByGroupId` / 질문 조회: `getQuestionByQuestionId` / 전체 그룹 질문 조회: `getAllGroupQuestionListByUserId`
  - [question controller, model, route 구현](https://github.com/QmA-project/QmA-server/commit/1f90ca6889c67f94d5e713781d4602a8125c6628)
  - [공개 질문 groupId 변경, route 경로 변경](https://github.com/QmA-project/QmA-server/commit/26555df39ff3ff7600f1c0e636894e9a557f7a07)
- 하나의 그룹에서 질문 목록 조회: `getGroupQuestionListByGroupId`
  - [질문 목록 조회 시 질문의 댓글 수도 조회되도록 추가](https://github.com/QmA-project/QmA-server/commit/047c9acaa6558541ccfe35135d36ea6612d3bbc6)
- 오늘의 질문 조회: `getDailyQuestion`
  - [오늘의 질문 조회 시 전달 받은 날짜 형식에서 % 와일드 문자 이용해서 YYYY-MM-DD 형식으로 DB 검색하도록 쿼리문 수정](https://github.com/QmA-project/QmA-server/commit/8e151aef437b6fa4cf8346fe925825851e675ad5) 
- HOT 질문 조회: `getDailyHotQuestion`
  - [HOT 질문 API 구현](https://github.com/QmA-project/QmA-server/commit/a44531379c8bb969e4656d38b3217032defddc95)